### PR TITLE
fix-linechart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 /.build
 /Packages
+/*.xcodeproj
 *xcworkspace/xcuserdata/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 /.build
 /Packages
-/*.xcodeproj
+*xcworkspace/xcuserdata/*

--- a/Sources/SwiftUICharts/LineChart/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChart/LineChartView.swift
@@ -64,7 +64,7 @@ public struct LineChartView: View {
                 if(!self.showIndicatorDot){
                     VStack(alignment: .leading, spacing: 8){
                         Text(self.title)
-                            .font(.title)
+                            .font(.headline)
                             .bold()
                             .foregroundColor(self.colorScheme == .dark ? self.darkModeStyle.textColor : self.style.textColor)
                         if (self.legend != nil){

--- a/Sources/SwiftUICharts/LineChart/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChart/LineChartView.swift
@@ -108,7 +108,7 @@ public struct LineChartView: View {
                          maxDataValue: .constant(nil)
                     )
                 }
-                .frame(width: frame.width, height: frame.height + 30)
+                .frame(width: frame.width, height: frame.height * 1.5)
                 .clipShape(RoundedRectangle(cornerRadius: 20))
                 .offset(x: 0, y: 0)
             }.frame(width: self.formSize.width, height: self.formSize.height)

--- a/Sources/SwiftUICharts/LineChart/LineChartView.swift
+++ b/Sources/SwiftUICharts/LineChart/LineChartView.swift
@@ -38,7 +38,7 @@ public struct LineChartView: View {
                 legend: String? = nil,
                 style: ChartStyle = Styles.lineChartStyleOne,
                 form: CGSize? = ChartForm.medium,
-                rateValue: Int? = 14,
+                rateValue: Int? = nil,
                 dropShadow: Bool? = true,
                 valueSpecifier: String? = "%.1f") {
         
@@ -58,7 +58,7 @@ public struct LineChartView: View {
         ZStack(alignment: .center){
             RoundedRectangle(cornerRadius: 20)
                 .fill(self.colorScheme == .dark ? self.darkModeStyle.backgroundColor : self.style.backgroundColor)
-                .frame(width: frame.width, height: 240, alignment: .center)
+                .frame(width: frame.width, height: frame.height*2, alignment: .center)
                 .shadow(color: self.style.dropShadowColor, radius: self.dropShadow ? 8 : 0)
             VStack(alignment: .leading){
                 if(!self.showIndicatorDot){


### PR DESCRIPTION
They made some very strange choices with hard coded values in this package... This PR makes it so the rounded rectangle for the line chart is no longer locked at 240 and now uses the appropriate size, and defaults the rateValue to nil so it doesn't show 14 anymore if you don't need a rate value 

Edit: Also updated the title font size in line chart because it was a different size from the bar chart, and increased the possible height for the line chart