### PR TITLE
fix bug with bar chart

### DIFF
--- a/Sources/SwiftUICharts/BarChart/BarChartView.swift
+++ b/Sources/SwiftUICharts/BarChart/BarChartView.swift
@@ -135,7 +135,11 @@ public struct BarChartView : View {
     
     func getCurrentValue() -> (String,Double)? {
         guard self.data.points.count > 0 else { return nil}
-        let index = max(0,min(self.data.points.count-1,Int(floor((self.touchLocation*self.formSize.width)/(self.formSize.width/CGFloat(self.data.points.count))))))
+        let num = floor((self.touchLocation*self.formSize.width)/(self.formSize.width/CGFloat(self.data.points.count)))
+        guard !(num.isNaN || num.isInfinite) else {
+            return nil
+        }
+        let index = max(0,min(self.data.points.count-1,Int(num)))
         return self.data.points[index]
     }
 }


### PR DESCRIPTION
This PR fixes the bug with the bar chart not checking for NaN/infinite numbers, which caused crashes on the harts tile view